### PR TITLE
feat: migrate license field from package.json to jsr.json

### DIFF
--- a/scripts/gen_types.js
+++ b/scripts/gen_types.js
@@ -35,6 +35,7 @@ export const JSRPublishSchema = z.object({
 export const JSRConfigurationSchema = z.object({
   name: JSRScopedNameSchema,
   version: z.optional(z.string()),
+  license: z.optional(z.string()),
   exports: JSRExportsSchema,
   publish: z.optional(JSRPublishSchema),
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -378,6 +378,7 @@ export function getExports(pkgJSON: PackageJson): Exports {
  *     "name": "package",
  *     "author": "author",
  *     "version": "1.0.0",
+ *     "license": "MIT",
  *     "files": ["src", "dist", "!node_modules"],
  *     "exports": {
  *       ".": "./src/index.ts",
@@ -390,6 +391,7 @@ export function getExports(pkgJSON: PackageJson): Exports {
  *  {
  *    "name": "@author/package",
  *    "version": "1.0.0",
+ *    "license": "MIT",
  *    "publish": {
  *      "include": ["src", "dist"],
  *      "exclude": ["node_modules"]
@@ -403,13 +405,14 @@ export function getExports(pkgJSON: PackageJson): Exports {
  * ```
  */
 export function genJsrFromPackageJson({ pkgJSON }: { pkgJSON: PackageJson }): JSRJson {
-	const { version } = pkgJSON;
+	const { version, license } = pkgJSON;
 
 	const include = getInclude(pkgJSON);
 	const exclude = getExclude(pkgJSON);
 	const jsr = {
 		name: getName(pkgJSON),
 		version: version as string,
+		...(license != null && { license }),
 		publish: include == null && exclude == null
 			? undefined
 			: {

--- a/src/jsr-schemas.ts
+++ b/src/jsr-schemas.ts
@@ -41,6 +41,7 @@ export type PackageJson = {
 	files?: string[];
 	exports?: string | Record<string, unknown>;
 	version?: string;
+	license?: string;
 	jsrName?: string;
 	jsrInclude?: string[];
 	jsrExclude?: string[];

--- a/tests/basic/jsr.json
+++ b/tests/basic/jsr.json
@@ -1,6 +1,7 @@
 {
 	"name": "@ryoppippi/dummy",
 	"version": "0.1.0",
+	"license": "MIT",
 	"exports": {
 		".": "./dist/index.js"
 	},

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -95,3 +95,16 @@ describe('name test', () => {
 		expect(() => genJsrFromPackageJson({ pkgJSON })).toThrowError();
 	});
 });
+
+describe('license field', () => {
+	it('migrates license from package.json to jsr.json', async () => {
+		const DIR = resolve(__dirname, './license_field/');
+		const pkgJsonPath = await findPackageJSON({ cwd: DIR });
+		const pkgJSON = await readPkgJSON(pkgJsonPath);
+		const jsr = genJsrFromPackageJson({ pkgJSON });
+
+		expect(jsr.license).toBe('MIT');
+		expect(jsr.name).toBe('@test-author/test-package');
+		expect(jsr.version).toBe('1.0.0');
+	});
+});

--- a/tests/license_field/jsr.json
+++ b/tests/license_field/jsr.json
@@ -1,0 +1,13 @@
+{
+	"name": "@test-author/test-package",
+	"version": "1.0.0",
+	"license": "MIT",
+	"publish": {
+		"include": [
+			"src"
+		]
+	},
+	"exports": {
+		".": "./src/index.ts"
+	}
+}

--- a/tests/license_field/package.json
+++ b/tests/license_field/package.json
@@ -1,0 +1,10 @@
+{
+	"name": "test-package",
+	"author": "test-author",
+	"version": "1.0.0",
+	"license": "MIT",
+	"files": ["src"],
+	"exports": {
+		".": "./src/index.ts"
+	}
+}


### PR DESCRIPTION
## Summary

This PR implements license field migration from package.json to jsr.json 
fixes: #329.

## Changes Made

- Add license field to PackageJson type in jsr-schemas.ts
- Extract license from package.json in genJsrFromPackageJson function  
- Update JSR schema generation script to include license field in zodConfiguration
- Add comprehensive test case for license field migration
- Update basic test snapshot to include license field

## Implementation Details

The license field is extracted from package.json and conditionally included in the generated jsr.json when present. This follows the same pattern as other optional fields like version.

## Test Coverage

- Added specific test case to verify license field migration from MIT license
- Updated existing basic test to expect license field in output
- All tests pass with the new implementation

Fixes #329

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added optional license field support in configuration and generated jsr.json when present in package.json.

- Documentation
  - Updated examples and snippets to show the license field usage in outputs and package.json.

- Tests
  - Added tests to validate license propagation from package.json to jsr.json.
  - Included new test fixtures demonstrating license inclusion alongside name, version, exports, and publish settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->