### PR TITLE
fix: update test snapshots for license field migration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,10 +58,10 @@ pkg-to-jsr is a zero-config CLI tool that generates `jsr.json` files from existi
 bun cli
 
 # Run tests with type checking
-bun test
+bun run test
 
 # Run tests in watch mode
-bun test --watch
+bun run test --watch
 
 # Type check the codebase
 bun typecheck
@@ -119,10 +119,10 @@ The project uses strict TypeScript rules including:
 bun run test
 
 # Run a specific test file
-bun test tests/basic/index.test.ts
+bun run test tests/basic/index.test.ts
 
 # Update test snapshots
-bun test -u
+bun run test -u
 ```
 
 ### Release Process

--- a/scripts/gen_zod_schemas.js
+++ b/scripts/gen_zod_schemas.js
@@ -116,6 +116,7 @@ export type PackageJson = {
 	files?: string[];
 	exports?: string | Record<string, unknown>;
 	version?: string;
+	license?: string;
 	jsrName?: string;
 	jsrInclude?: string[];
 	jsrExclude?: string[];

--- a/tests/exports_with_jsr/jsr.json
+++ b/tests/exports_with_jsr/jsr.json
@@ -1,6 +1,7 @@
 {
 	"name": "@ryoppippi/dummy",
 	"version": "0.1.0",
+	"license": "MIT",
 	"exports": {
 		".": "./src/index.ts"
 	},

--- a/tests/exports_without_jsr/jsr.json
+++ b/tests/exports_without_jsr/jsr.json
@@ -1,6 +1,7 @@
 {
 	"name": "@ryoppippi/dummy",
 	"version": "0.1.0",
+	"license": "MIT",
 	"exports": {
 		".": "./dist/index.js"
 	},

--- a/tests/exports_without_jsr_imports_object/jsr.json
+++ b/tests/exports_without_jsr_imports_object/jsr.json
@@ -1,6 +1,7 @@
 {
 	"name": "@ryoppippi/dummy",
 	"version": "0.1.0",
+	"license": "MIT",
 	"exports": {
 		".": "./dist/index.js"
 	},

--- a/tests/files_excludes/jsr.json
+++ b/tests/files_excludes/jsr.json
@@ -1,6 +1,7 @@
 {
 	"name": "@ryoppippi/dummy",
 	"version": "0.1.0",
+	"license": "MIT",
 	"exports": {
 		".": "./dist/index.js"
 	},

--- a/tests/files_includes/jsr.json
+++ b/tests/files_includes/jsr.json
@@ -1,6 +1,7 @@
 {
 	"name": "@ryoppippi/dummy",
 	"version": "0.1.0",
+	"license": "MIT",
 	"exports": {
 		".": "./dist/index.js"
 	},

--- a/tests/files_without_files/jsr.json
+++ b/tests/files_without_files/jsr.json
@@ -1,6 +1,7 @@
 {
 	"name": "@dummy/dummy",
 	"version": "0.1.0",
+	"license": "MIT",
 	"exports": {
 		".": "./dist/index.js"
 	}

--- a/tests/name_gen_name/jsr.json
+++ b/tests/name_gen_name/jsr.json
@@ -1,6 +1,7 @@
 {
 	"name": "@ryoppippi/dummy",
 	"version": "0.1.0",
+	"license": "MIT",
 	"exports": {
 		".": "./dist/index.js"
 	}

--- a/tests/name_jsrName/jsr.json
+++ b/tests/name_jsrName/jsr.json
@@ -1,6 +1,7 @@
 {
 	"name": "@ryoppippi/helloworld",
 	"version": "0.1.0",
+	"license": "MIT",
 	"exports": {
 		".": "./dist/index.js"
 	}


### PR DESCRIPTION
## Summary

- Update test snapshots to include license field after license migration feature
- Add license field to PackageJson type definition to fix type errors
- Update CLAUDE.md documentation to use bun run test instead of bun test

## Test plan

- [x] All tests pass with updated snapshots
- [x] Type checking passes without errors  
- [x] Linting passes without errors
- [x] Documentation is consistent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for an optional license field in package metadata, now recognized by the schema and available in the exported types.

- Documentation
  - Updated testing instructions to use bun run test for consistency across examples.

- Tests
  - Extended test fixtures to include license metadata in package manifests, ensuring coverage for the new field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->